### PR TITLE
[#21] fix evidence can't locate local duckdb files

### DIFF
--- a/motherduck-dagster-hybrid-compute/.env.example
+++ b/motherduck-dagster-hybrid-compute/.env.example
@@ -13,5 +13,15 @@ DUCKDB_DATABASE="md:dagster_hybrid_demo?motherduck_token=..."
 #  - https://motherduck.com/docs/integrations/evidence/
 #  - https://docs.evidence.dev/cli#environment-variables
 #
-EVIDENCE_SOURCE__DAGSTER_HYBRID_DEMO__TYPE="duckdb"
-EVIDENCE_SOURCE__DAGSTER_HYBRID_DEMO__FILENAME="md:?motherduck_token=..."
+EVIDENCE_SOURCE__dagster_hybrid_demo__type="duckdb"
+EVIDENCE_SOURCE__dagster_hybrid_demo__filename="md:?motherduck_token=..."
+
+# Running the Project Locally
+#
+# To run the project using a duck db file you've saved to disk, use the following example config.
+# The duckdb file has to be specified with an absolute path, whilst the evidence source has to be
+# specified as a relative path from the `./reports/sources/dagster_hybrid_demo/` directory.
+#
+# DUCKDB_DATABASE="/home/UserName/dev/dagster-devrel-fork/motherduck-dagster-hybrid-compute/data/db/local.duckdb"
+# EVIDENCE_SOURCE__dagster_hybrid_demo__filename="../../../data/db/local.duckdb"
+

--- a/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/all_ducks.sql
+++ b/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/all_ducks.sql
@@ -17,7 +17,7 @@ select
   population_city,
   survey_site_size
 
-from dagster_hybrid_demo.main.all_birds
+from main.all_birds
 
 where
   lower(bird_name) like '%duck%'

--- a/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/connection.yaml
+++ b/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/connection.yaml
@@ -1,5 +1,10 @@
 # This file was automatically generated
 name: dagster_hybrid_demo
 type: duckdb
+# The following `filename` env variable is read from the .env file in the project root.
 options:
-  filename: md:?motherduck_token=<replace>
+  # For local use, use relative path from this directory, e.g.
+  # filename: ../../../local.duckdb
+  #
+  # For use with motherduck cloud, use connection string, e.g.
+  # filename: md:?motherduck_token=<replace>

--- a/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/top_ducks_by_region.sql
+++ b/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/top_ducks_by_region.sql
@@ -5,4 +5,4 @@ select
     bird_name,
     total_count
 
-from dagster_hybrid_demo.main.top_ducks_by_region
+from main.top_ducks_by_region

--- a/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/top_ducks_by_state.sql
+++ b/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/top_ducks_by_state.sql
@@ -4,4 +4,4 @@ select
     state,
     total_species_count
 
-from dagster_hybrid_demo.main.top_ducks_by_state
+from main.top_ducks_by_state

--- a/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/top_ducks_by_year.sql
+++ b/motherduck-dagster-hybrid-compute/reports/sources/dagster_hybrid_demo/top_ducks_by_year.sql
@@ -6,4 +6,4 @@ select
   region,
   species_count
 
-from dagster_hybrid_demo.main.top_ducks_by_year
+from main.top_ducks_by_year


### PR DESCRIPTION
export case sensitive evidence environment variables.

also provided instructions in .env.example on how to configure project for local use.

removed `dagster_hybrid_demo.` from schema name in FROM statement as the tables created by duckdb exist in the `main` schema, was causing error where evidence couldn't find the data sources.